### PR TITLE
修复原神获取祈愿记录API中表述的小问题

### DIFF
--- a/hoyolab/user/game_account_info.md
+++ b/hoyolab/user/game_account_info.md
@@ -1865,7 +1865,7 @@ auth_appid
 | 字段 | 类型 | 内容 | 备注 |
 | ---- | ---- | ---- | ---- |
 | uid | str | 该玩家的UID | |
-| gacha_type | str | 祈愿池 | 与请求参数中的`gacha_type`参数的值相同 |
+| gacha_type | str | 祈愿池 | 与请求参数中的`gacha_type`参数的值相同（角色活动祈愿-2除外，为`400`） |
 | item_id | str | 似乎总是为空字符串 | |
 | count | str | 1 | |
 | time | str | 该玩家抽到该项目的日期 | |


### PR DESCRIPTION
对于角色活动祈愿-2 的祈愿记录，返回数据中的 `gacha_type` 为 `400`，并非与请求参数中的 `gacha_type` 相同