### PR TITLE
添加x-rpc-device_id对于安卓设备的说明

### DIFF
--- a/other/authentication.md
+++ b/other/authentication.md
@@ -81,6 +81,20 @@ _注：以下列表只是说明该请求头的值通常在哪些平台出现，�
 
 设备ID，由使用的设备决定。
 
+安卓上一般为一串由`ANDROID_ID`生成的`UUID`，Kotlin 中可以这样获取（Java 同理）
+```Kotlin
+import android.content.Context
+import android.provider.Settings
+import java.util.UUID
+
+@SuppressLint("HardwareIds")
+fun getDeviceId(context: Context): String {
+    val androidId = Settings.Secure.getString(context.contentResolver, Settings.System.ANDROID_ID)
+    val uuid = UUID.nameUUIDFromBytes(androidId.toByteArray())
+    return uuid.toString()
+}
+```
+
 #### `X-Requested-With`
 
 国内版APP为`com.mihoyo.hyperion`。


### PR DESCRIPTION
添加`x-rpc-device_id`对于安卓设备的说明及如何获取的 Kotlin 代码

#### 来源：

自己测试的

通过 Charles 抓包请求头获取`x-rpc-device_id`，发现其值在同一设备上不会改变且格式为 UUID 的格式，于是写了一个简单的测试App试验对比出其值来源为`Settings.System.ANDROID_ID`